### PR TITLE
ci: 💚 pin pin minor version of the golangci-lint

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -19,3 +19,5 @@ jobs:
       - name: Run golangci-lint
         id: golangci-lint
         uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.56


### PR DESCRIPTION
I experienced bugs in the new versions of golangci-lint in the past.
